### PR TITLE
Giving each nav item the same weight so items are aligned properly

### DIFF
--- a/bubble-navigation-bar-compose/src/main/java/com/commandiron/bubble_navigation_bar_compose/BubbleNavigationBarItem.kt
+++ b/bubble-navigation-bar-compose/src/main/java/com/commandiron/bubble_navigation_bar_compose/BubbleNavigationBarItem.kt
@@ -78,6 +78,7 @@ fun RowScope.BubbleNavigationBarItem(
     BoxWithConstraints(
         modifier = modifier
             .fillMaxHeight()
+            .weight(1f)
             .clickable(
                 interactionSource = interactionSource,
                 indication = null


### PR DESCRIPTION
Currently, items are not always centered correctly. If you have 3 items for example, the middle item's icon is not in the center of the screen when one of the other to tabs are pressed. 

This PR fixes that